### PR TITLE
Add static page listing candidates with strong preference votes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="utf-8" />
+  <title>Preferenční hlasy – volby 2021</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="layout">
+    <h1>Preferenční hlasy kandidátů</h1>
+    <p class="lead">Načtení dat ze serveru volby.cz může chvíli trvat. Zobrazí se pouze kandidáti, kteří získali alespoň 5&nbsp;% hlasů své strany v daném kraji.</p>
+    <section id="status" class="status" aria-live="polite">Načítám data…</section>
+    <section class="table-wrapper hidden" id="results-section">
+      <table id="results-table">
+        <thead>
+          <tr>
+            <th scope="col">Kraj</th>
+            <th scope="col">Číslo kandidáta</th>
+            <th scope="col">Jméno</th>
+            <th scope="col">Číslo strany</th>
+            <th scope="col">Strana</th>
+            <th scope="col">Preferenční hlasy</th>
+            <th scope="col">Hlasů strany celkem</th>
+            <th scope="col">Podíl</th>
+          </tr>
+        </thead>
+        <tbody id="results-body"></tbody>
+      </table>
+    </section>
+  </main>
+  <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,213 @@
+const CANDIDATES_URL = 'https://www.volby.cz/pls/ps2021/vysledky_kandid';
+const PARTY_DICTIONARY_URL = 'https://www.volby.cz/opendata/ps2021/xml/cvs.xml';
+
+const statusElement = document.getElementById('status');
+const resultsSection = document.getElementById('results-section');
+const tableBody = document.getElementById('results-body');
+
+function setStatus(message, isError = false) {
+  statusElement.textContent = message;
+  statusElement.classList.toggle('error', isError);
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('cs-CZ').format(value);
+}
+
+function formatPercent(numerator, denominator) {
+  if (!denominator) {
+    return '—';
+  }
+  const value = (numerator / denominator) * 100;
+  return `${value.toFixed(2).replace('.', ',')} %`;
+}
+
+function parseNumber(value) {
+  if (typeof value !== 'string') {
+    return Number.NaN;
+  }
+  const normalized = value.replace(/\s+/g, '').replace(/\u00a0/g, '');
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isNaN(parsed) ? Number.NaN : parsed;
+}
+
+function getNodeValue(node, possibleNames) {
+  for (const name of possibleNames) {
+    if (node.hasAttribute?.(name)) {
+      const value = node.getAttribute(name);
+      if (value !== null) {
+        return value.trim();
+      }
+    }
+    const child = node.querySelector?.(name);
+    if (child && child.textContent) {
+      return child.textContent.trim();
+    }
+  }
+  return undefined;
+}
+
+async function fetchXml(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Načtení ${url} selhalo (HTTP ${response.status}).`);
+  }
+  const text = await response.text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(text, 'application/xml');
+  if (doc.querySelector('parsererror')) {
+    throw new Error(`Dokument z ${url} není platné XML.`);
+  }
+  return doc;
+}
+
+function buildPartyDictionary(dictionaryDoc) {
+  const dictionary = new Map();
+  dictionaryDoc.querySelectorAll('STRANA').forEach((party) => {
+    const id = getNodeValue(party, ['KSTRANA', 'CIS_STRANA', 'CISLO_STRANY']);
+    const name = getNodeValue(party, ['NAZEV', 'NAZ_STRANA', 'NAZEV_STRANY']);
+    if (id) {
+      dictionary.set(id, name ?? '');
+    }
+  });
+  return dictionary;
+}
+
+function extractPartyVotes(regionNode) {
+  const map = new Map();
+  const partiesRoot = regionNode.querySelector('STRANY');
+  if (!partiesRoot) {
+    return map;
+  }
+  partiesRoot.querySelectorAll('STRANA').forEach((partyNode) => {
+    const id = getNodeValue(partyNode, ['CISLO_STRANY', 'KSTRANA']);
+    const voteCount = parseNumber(getNodeValue(partyNode, ['POC_HLASU', 'HLASY']));
+    if (id && Number.isFinite(voteCount)) {
+      map.set(id, voteCount);
+    }
+  });
+  return map;
+}
+
+function extractQualifiedCandidates(regionNode, partyNames) {
+  const results = [];
+  const regionName = getNodeValue(regionNode, ['NAZEV_KRAJ', 'NAZ_KRAJ']);
+  const partyVotes = extractPartyVotes(regionNode);
+  const candidatesRoot = regionNode.querySelector('KANDIDATI');
+  if (!candidatesRoot) {
+    return results;
+  }
+
+  candidatesRoot.querySelectorAll('KANDIDAT').forEach((candidateNode) => {
+    const partyId = getNodeValue(candidateNode, ['STRANA', 'KSTRANA', 'CISLO_STRANY']);
+    const candidateNumber = getNodeValue(candidateNode, ['POR_STRANA', 'PORADOVE_CISLO', 'PORCISLO', 'PORADI']);
+    const firstName = getNodeValue(candidateNode, ['JMENO']);
+    const lastName = getNodeValue(candidateNode, ['PRIJMENI']);
+    const votes = parseNumber(
+      getNodeValue(candidateNode, [
+        'HLASY',
+        'POC_PREFERENC',
+        'POC_PREDNOST',
+        'POC_PREDNOSTNI',
+        'POC_PREFERENCNICH',
+      ]),
+    );
+
+    if (!partyId || !Number.isFinite(votes)) {
+      return;
+    }
+
+    const totalPartyVotes = partyVotes.get(partyId);
+    if (!Number.isFinite(totalPartyVotes)) {
+      return;
+    }
+
+    if (votes >= totalPartyVotes * 0.05) {
+      results.push({
+        regionName: regionName ?? 'Neznámý kraj',
+        candidateNumber: candidateNumber ?? '—',
+        candidateName: [firstName, lastName].filter(Boolean).join(' ') || 'Bez jména',
+        partyId,
+        partyName: partyNames.get(partyId) ?? 'Neznámá strana',
+        votes,
+        totalPartyVotes,
+        ratio: votes / totalPartyVotes,
+      });
+    }
+  });
+
+  return results;
+}
+
+function renderResults(candidates) {
+  tableBody.replaceChildren();
+  const fragment = document.createDocumentFragment();
+
+  candidates
+    .sort((a, b) => {
+      if (a.regionName !== b.regionName) {
+        return a.regionName.localeCompare(b.regionName, 'cs');
+      }
+      if (a.partyId !== b.partyId) {
+        return a.partyId.localeCompare(b.partyId, 'cs');
+      }
+      return (a.candidateNumber || '').localeCompare(b.candidateNumber || '', 'cs', { numeric: true });
+    })
+    .forEach((item) => {
+      const row = document.createElement('tr');
+
+      const cells = [
+        item.regionName,
+        item.candidateNumber,
+        item.candidateName,
+        item.partyId,
+        item.partyName,
+        formatNumber(item.votes),
+        formatNumber(item.totalPartyVotes),
+        formatPercent(item.votes, item.totalPartyVotes),
+      ];
+
+      cells.forEach((value) => {
+        const cell = document.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
+
+      fragment.appendChild(row);
+    });
+
+  tableBody.appendChild(fragment);
+}
+
+async function init() {
+  try {
+    setStatus('Načítám data ze serveru volby.cz…');
+    const [candidatesDoc, partyDictionaryDoc] = await Promise.all([
+      fetchXml(CANDIDATES_URL),
+      fetchXml(PARTY_DICTIONARY_URL),
+    ]);
+
+    const partyNames = buildPartyDictionary(partyDictionaryDoc);
+    const qualifiedCandidates = [];
+
+    candidatesDoc.querySelectorAll('KRAJ').forEach((regionNode) => {
+      qualifiedCandidates.push(
+        ...extractQualifiedCandidates(regionNode, partyNames),
+      );
+    });
+
+    if (qualifiedCandidates.length === 0) {
+      setStatus('Žádný kandidát nesplnil požadovaný limit preferenčních hlasů.');
+      return;
+    }
+
+    renderResults(qualifiedCandidates);
+    setStatus(`Nalezeno ${qualifiedCandidates.length} kandidátů splňujících podmínku.`);
+    resultsSection.classList.remove('hidden');
+  } catch (error) {
+    console.error(error);
+    setStatus(error.message || 'Při načítání dat došlo k chybě.', true);
+  }
+}
+
+init();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,100 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.5;
+  --max-width: 1200px;
+  --surface: rgba(255, 255, 255, 0.75);
+  --border-color: rgba(0, 0, 0, 0.2);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, #f0f4ff, #ffffff);
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1rem 4rem;
+}
+
+.layout {
+  width: min(100%, var(--max-width));
+  background: var(--surface);
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow);
+  padding: 2rem 2.5rem;
+  backdrop-filter: blur(12px);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: clamp(2rem, 3vw, 2.75rem);
+}
+
+.lead {
+  margin-bottom: 1.5rem;
+  font-size: 1rem;
+  color: #444;
+}
+
+.status {
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+}
+
+.status.error {
+  border-color: #d93025;
+  color: #d93025;
+  background: rgba(217, 48, 37, 0.08);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.hidden {
+  display: none;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+th,
+td {
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: rgba(0, 0, 0, 0.04);
+  position: sticky;
+  top: 0;
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem 0.75rem 3rem;
+  }
+
+  .layout {
+    padding: 1.5rem;
+  }
+
+  table {
+    font-size: 0.85rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static HTML page that loads parliamentary election data from volby.cz
- implement client-side processing to list candidates with at least 5% of their party's votes and show party names
- style the page and display loading or error states during fetches

## Testing
- not run (static frontend)

------
https://chatgpt.com/codex/tasks/task_e_68d57431187c8332ac79d34f60aeb2e5