### PR TITLE
Add Netlify proxy and static demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# volby
+# volby static proxy demo
+
+This project deploys a static front-end alongside a Netlify serverless function
+that proxies requests to external APIs. The proxy adds permissive CORS headers
+and avoids mixed-content restrictions by fetching remote data on the server
+side.
+
+## Local development
+
+Install the Netlify CLI if you want to run the function locally:
+
+```bash
+npm install -g netlify-cli
+```
+
+Then run the development server, which serves the static assets from `public/`
+and mounts the proxy function at `/.netlify/functions/proxy`:
+
+```bash
+netlify dev
+```
+
+Visit <http://localhost:8888> and use the form to fetch remote JSON via the
+proxy.
+
+## Deployment
+
+1. Push this repository to GitHub.
+2. Create a new site on Netlify and connect it to the repository.
+3. When prompted for build settings, set:
+   - **Build command:** (leave empty)
+   - **Publish directory:** `public`
+4. Deploy the site. Netlify will automatically build the static assets and
+   expose the proxy function at `/.netlify/functions/proxy`.
+
+The static JavaScript code issues requests to `/api?url=…`. The redirect defined
+in `netlify.toml` forwards those calls to the proxy function so your browser no
+longer connects directly to the external domain.
+
+## Using the proxy
+
+Send a GET request to `/.netlify/functions/proxy` (or simply `/api`) with the
+query parameter `url` set to the external resource you want to fetch. Example:
+
+```bash
+curl 'https://your-site.netlify.app/api?url=https://api.example.com/data'
+```
+
+The proxy streams the upstream response back to the browser while injecting the
+`Access-Control-Allow-Origin: *` header so client-side code served from a static
+site can consume the data safely.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  publish = "public"
+  command = ""
+
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/proxy"
+  status = 200

--- a/netlify/functions/proxy.js
+++ b/netlify/functions/proxy.js
@@ -1,0 +1,58 @@
+const DEFAULT_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,HEAD,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Max-Age': '86400'
+};
+
+const createResponse = (statusCode, body, extraHeaders = {}) => ({
+  statusCode,
+  headers: {
+    ...DEFAULT_HEADERS,
+    ...extraHeaders
+  },
+  body
+});
+
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return createResponse(204, '');
+  }
+
+  const targetUrl = event.queryStringParameters?.url;
+
+  if (!targetUrl) {
+    return createResponse(400, JSON.stringify({ error: 'Missing `url` query parameter.' }), {
+      'Content-Type': 'application/json'
+    });
+  }
+
+  try {
+    const upstreamResponse = await fetch(targetUrl, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json, text/plain, */*'
+      }
+    });
+
+    const buffer = Buffer.from(await upstreamResponse.arrayBuffer());
+    const isBinary = !/^text\//i.test(upstreamResponse.headers.get('content-type') || '') &&
+      !(upstreamResponse.headers.get('content-type') || '').includes('json');
+
+    return {
+      statusCode: upstreamResponse.status,
+      headers: {
+        ...DEFAULT_HEADERS,
+        'Content-Type': upstreamResponse.headers.get('content-type') || 'application/octet-stream',
+        'Cache-Control': upstreamResponse.headers.get('cache-control') || 'no-store'
+      },
+      body: isBinary ? buffer.toString('base64') : buffer.toString('utf8'),
+      isBase64Encoded: isBinary
+    };
+  } catch (error) {
+    console.error('Proxy request failed', error);
+    return createResponse(502, JSON.stringify({ error: 'Proxy failed to fetch remote resource.' }), {
+      'Content-Type': 'application/json'
+    });
+  }
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Volby Data Proxy Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Remote Data Fetch via Serverless Proxy</h1>
+      <p>
+        Use the form below to fetch JSON data from an external endpoint. The
+        request is routed through a small serverless function that adds the
+        necessary CORS headers so the response can be consumed by a static site
+        hosted on GitHub Pages or Netlify.
+      </p>
+      <form id="fetch-form">
+        <label for="target-url">External URL</label>
+        <input
+          id="target-url"
+          name="target-url"
+          type="url"
+          placeholder="https://api.example.com/data"
+          required
+        />
+        <button type="submit">Fetch via Proxy</button>
+      </form>
+      <section id="result" aria-live="polite"></section>
+    </main>
+    <script src="main.js" type="module"></script>
+  </body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,50 @@
+const form = document.querySelector('#fetch-form');
+const result = document.querySelector('#result');
+
+const renderResult = (content, isError = false) => {
+  result.innerHTML = '';
+  const pre = document.createElement('pre');
+  pre.textContent = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
+  pre.className = isError ? 'error' : '';
+  result.appendChild(pre);
+};
+
+const setLoading = (isLoading) => {
+  form.querySelector('button').disabled = isLoading;
+  form.querySelector('button').textContent = isLoading ? 'Fetching…' : 'Fetch via Proxy';
+};
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const url = new FormData(form).get('target-url');
+  if (!url) return;
+
+  setLoading(true);
+  renderResult('');
+
+  try {
+    const response = await fetch(`/api?url=${encodeURIComponent(url)}`);
+    const contentType = response.headers.get('content-type') || '';
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Proxy returned ${response.status}: ${errorText}`);
+    }
+
+    if (contentType.includes('application/json')) {
+      const data = await response.json();
+      renderResult(data);
+    } else if (contentType.includes('text/')) {
+      const text = await response.text();
+      renderResult(text);
+    } else {
+      const blob = await response.blob();
+      renderResult(`Received ${contentType} (${blob.size} bytes). Save or process as needed.`);
+    }
+  } catch (error) {
+    console.error(error);
+    renderResult(error.message || 'Proxy request failed.', true);
+  } finally {
+    setLoading(false);
+  }
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #f7f8fb, #dfe3ee);
+}
+
+main {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 1rem;
+  padding: 2rem;
+  width: min(90vw, 640px);
+  box-shadow: 0 1.25rem 3rem -2rem rgba(31, 41, 55, 0.6);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+}
+
+form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input[type='url'] {
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+}
+
+button {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #2563eb, #9333ea);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0.75rem 1.5rem -1rem rgba(79, 70, 229, 0.7);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+#result {
+  margin-top: 1.5rem;
+  min-height: 4rem;
+}
+
+pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  overflow-x: auto;
+}
+
+pre.error {
+  background: #7f1d1d;
+}


### PR DESCRIPTION
## Summary
- add a static demo page that calls a proxy endpoint instead of the remote API directly
- configure a Netlify serverless function to fetch external resources and add permissive CORS headers
- document local development, deployment and usage instructions for the proxy

## Testing
- not run (static site only)


------
https://chatgpt.com/codex/tasks/task_e_68d5ba97b72083328e0c6dccd6650a8a