### PR TITLE
Create frontend page for displaying preferential vote results

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,21 @@
         <span class="status__text">Načítám data…</span>
       </section>
 
-      <section id="results" class="results" hidden></section>
+      <section id="results" class="results" hidden>
+        <div class="results__controls">
+          <label class="results__label" for="regionSelect">Vyberte kraj:</label>
+          <select id="regionSelect" class="results__select" disabled>
+            <option>Načítám…</option>
+          </select>
+        </div>
+
+        <header class="region-header">
+          <h2 id="regionHeading" class="region-header__title"></h2>
+          <p id="regionMeta" class="region-header__meta" hidden></p>
+        </header>
+
+        <div id="regionParties" class="region-parties"></div>
+      </section>
     </main>
 
     <script src="main.js" type="module"></script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="cs">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Výsledky preferenčních hlasů</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__header">
+        <h1>Výsledky preferenčních hlasů</h1>
+        <p class="page__intro">
+          Tato stránka načte soubor <code>ps.xml</code> ze serveru a zobrazí kandidáty,
+          kteří získali dostatečný počet preferenčních hlasů.
+        </p>
+      </header>
+
+      <section id="status" class="status" role="status" aria-live="polite">
+        <span class="status__icon" aria-hidden="true">⏳</span>
+        <span class="status__text">Načítám data…</span>
+      </section>
+
+      <section id="results" class="results" hidden></section>
+    </main>
+
+    <script src="main.js" type="module"></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,391 @@
+const PREFERENCE_THRESHOLD_RATIO = 0.05;
+const PARTY_TAG_NAMES = [
+  "STRANA",
+  "STRANA_KANDIDATKA",
+  "KANDIDATKA",
+  "PARTY",
+  "LIST",
+  "LISTINA"
+];
+const PARTY_NAME_TAGS = [
+  "NAZEV",
+  "NAZEV_STRANY",
+  "STRANA",
+  "PARTY_NAME",
+  "NAZEV_KANDIDATKY",
+  "NAZEV_PARTY"
+];
+const PARTY_TOTAL_VOTES_TAGS = [
+  "HLASY_STRANA",
+  "HLASY",
+  "VOTES",
+  "HLASY_CELKEM",
+  "HLASY_PLATNE",
+  "TOTAL_VOTES"
+];
+const CANDIDATE_TAG_NAMES = [
+  "KANDIDAT",
+  "KANDIDATKA",
+  "CANDIDATE",
+  "OSOBA",
+  "PERSON"
+];
+const CANDIDATE_FIRST_NAME_TAGS = [
+  "JMENO",
+  "KRESTNI_JMENO",
+  "FIRST_NAME",
+  "KRESTNIJMENO"
+];
+const CANDIDATE_LAST_NAME_TAGS = [
+  "PRIJMENI",
+  "SURNAME",
+  "LAST_NAME"
+];
+const CANDIDATE_TITLE_PREFIX_TAGS = ["TITUL_PRED", "TITLE_BEFORE"];
+const CANDIDATE_TITLE_SUFFIX_TAGS = ["TITUL_ZA", "TITLE_AFTER"];
+const CANDIDATE_VOTES_TAGS = [
+  "PREFERENCNI_HLASY",
+  "PREF_HLASY",
+  "HLASY",
+  "VOTES",
+  "PREF_VOTES",
+  "PREFERENTIAL_VOTES"
+];
+
+const statusContainer = document.querySelector("#status");
+const statusText = statusContainer.querySelector(".status__text");
+const statusIcon = statusContainer.querySelector(".status__icon");
+const resultsContainer = document.querySelector("#results");
+
+document.addEventListener("DOMContentLoaded", () => {
+  loadAndRender();
+});
+
+async function loadAndRender() {
+  try {
+    const response = await fetch("ps.xml", { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Server vrátil stav ${response.status}`);
+    }
+
+    const xmlText = await response.text();
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlText, "application/xml");
+
+    const parseError = xmlDoc.querySelector("parsererror");
+    if (parseError) {
+      throw new Error("XML soubor se nepodařilo zpracovat.");
+    }
+
+    const parties = extractParties(xmlDoc);
+    if (!parties.length) {
+      throw new Error("V souboru nebyly nalezeny žádné kandidující subjekty.");
+    }
+
+    renderParties(parties);
+    updateStatus(
+      `Načteno ${parties.length} ${decline(parties.length, "subjekt", "subjekty", "subjektů")}.`,
+      "success",
+      "✅"
+    );
+  } catch (error) {
+    console.error(error);
+    updateStatus(error.message || "Nepodařilo se načíst data.", "error", "⚠️");
+  }
+}
+
+function extractParties(xmlDoc) {
+  const partyElements = findElementsByTagNames(
+    xmlDoc.documentElement,
+    PARTY_TAG_NAMES
+  );
+
+  const parties = partyElements.map((partyElement) => parseParty(partyElement));
+  return parties.filter(Boolean);
+}
+
+function parseParty(partyElement) {
+  const partyName =
+    findTextByTagNames(partyElement, PARTY_NAME_TAGS) ||
+    getAttributeByNames(partyElement, PARTY_NAME_TAGS) ||
+    "Neznámý subjekt";
+
+  let totalVotes = findNumberByTagNames(partyElement, PARTY_TOTAL_VOTES_TAGS);
+  if (!Number.isFinite(totalVotes)) {
+    const fallbackAttribute = getAttributeByNames(
+      partyElement,
+      PARTY_TOTAL_VOTES_TAGS,
+      true
+    );
+    totalVotes = fallbackAttribute;
+  }
+
+  const candidates = extractCandidates(partyElement);
+
+  if (!Number.isFinite(totalVotes)) {
+    const summedVotes = candidates.reduce((acc, candidate) => {
+      return acc + (candidate.preferenceVotes || 0);
+    }, 0);
+    totalVotes = summedVotes || 0;
+  }
+
+  const threshold = Math.ceil(totalVotes * PREFERENCE_THRESHOLD_RATIO);
+
+  const enhancedCandidates = candidates.map((candidate) => ({
+    ...candidate,
+    qualifies: candidate.preferenceVotes >= threshold && threshold > 0,
+  }));
+
+  const qualifiedCandidates = enhancedCandidates.filter(
+    (candidate) => candidate.qualifies
+  );
+
+  return {
+    partyName,
+    totalVotes,
+    threshold,
+    candidates: enhancedCandidates,
+    qualifiedCandidates,
+  };
+}
+
+function extractCandidates(partyElement) {
+  let candidateElements = findElementsByTagNames(
+    partyElement,
+    CANDIDATE_TAG_NAMES,
+    { onlyChildrenOf: partyElement }
+  );
+
+  if (!candidateElements.length) {
+    candidateElements = findElementsByTagNames(
+      partyElement,
+      CANDIDATE_TAG_NAMES
+    );
+  }
+
+  return candidateElements
+    .map((candidateElement) => parseCandidate(candidateElement))
+    .filter(Boolean);
+}
+
+function parseCandidate(candidateElement) {
+  const prefix =
+    findTextByTagNames(candidateElement, CANDIDATE_TITLE_PREFIX_TAGS) || "";
+  const firstName =
+    findTextByTagNames(candidateElement, CANDIDATE_FIRST_NAME_TAGS) || "";
+  const lastName =
+    findTextByTagNames(candidateElement, CANDIDATE_LAST_NAME_TAGS) || "";
+  const suffix =
+    findTextByTagNames(candidateElement, CANDIDATE_TITLE_SUFFIX_TAGS) || "";
+
+  let displayName =
+    `${prefix} ${[firstName, lastName].filter(Boolean).join(" ")}`.trim();
+  if (!displayName) {
+    displayName = (candidateElement.textContent || "").trim();
+  }
+  if (suffix) {
+    displayName = `${displayName}, ${suffix}`;
+  }
+
+  const preferenceVotes = findNumberByTagNames(
+    candidateElement,
+    CANDIDATE_VOTES_TAGS
+  );
+
+  const votesFromAttribute = getAttributeByNames(
+    candidateElement,
+    CANDIDATE_VOTES_TAGS,
+    true
+  );
+
+  const totalVotes = Number.isFinite(preferenceVotes)
+    ? preferenceVotes
+    : votesFromAttribute;
+
+  if (!Number.isFinite(totalVotes)) {
+    return null;
+  }
+
+  return {
+    name: displayName || "Neznámý kandidát",
+    preferenceVotes: totalVotes,
+  };
+}
+
+function renderParties(parties) {
+  const fragment = document.createDocumentFragment();
+  parties.forEach((party) => {
+    const partySection = document.createElement("article");
+    partySection.className = "party";
+
+    const header = document.createElement("header");
+    header.className = "party__header";
+
+    const title = document.createElement("h2");
+    title.className = "party__title";
+    title.textContent = party.partyName;
+
+    const meta = document.createElement("p");
+    meta.className = "party__meta";
+    meta.innerHTML = `Celkem hlasů: <strong>${formatNumber(
+      party.totalVotes
+    )}</strong> · Limit pro posun: <strong>${formatNumber(
+      party.threshold
+    )}</strong>`;
+
+    header.append(title, meta);
+
+    const table = document.createElement("table");
+    table.className = "candidate-table";
+
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    ["Kandidát", "Preferenční hlasy", "Splněno"].forEach((label) => {
+      const th = document.createElement("th");
+      th.textContent = label;
+      headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+
+    const tbody = document.createElement("tbody");
+
+    if (!party.candidates.length) {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      cell.colSpan = 3;
+      cell.className = "candidate-table__note";
+      cell.textContent = "U tohoto subjektu nebyli nalezeni žádní kandidáti.";
+      row.appendChild(cell);
+      tbody.appendChild(row);
+    } else {
+      party.candidates
+        .sort((a, b) => b.preferenceVotes - a.preferenceVotes)
+        .forEach((candidate) => {
+          const row = document.createElement("tr");
+          if (candidate.qualifies) {
+            row.classList.add("is-qualified");
+          }
+
+          const nameCell = document.createElement("td");
+          nameCell.textContent = candidate.name;
+
+          const votesCell = document.createElement("td");
+          votesCell.textContent = formatNumber(candidate.preferenceVotes);
+
+          const qualifiesCell = document.createElement("td");
+          qualifiesCell.textContent = candidate.qualifies ? "Ano" : "Ne";
+
+          row.append(nameCell, votesCell, qualifiesCell);
+          tbody.appendChild(row);
+        });
+    }
+
+    table.append(thead, tbody);
+    partySection.append(header, table);
+    fragment.appendChild(partySection);
+  });
+
+  resultsContainer.replaceChildren(fragment);
+  resultsContainer.hidden = false;
+}
+
+function updateStatus(message, type = "info", icon = "ℹ️") {
+  statusText.textContent = message;
+  statusIcon.textContent = icon;
+  statusContainer.classList.remove("status--error", "status--success");
+  if (type === "error") {
+    statusContainer.classList.add("status--error");
+  } else if (type === "success") {
+    statusContainer.classList.add("status--success");
+  }
+}
+
+function findElementsByTagNames(root, names, options = {}) {
+  const normalizedNames = names.map((name) => name.toLowerCase());
+  const elements = [];
+  const stack = options.onlyChildrenOf
+    ? Array.from(options.onlyChildrenOf.children)
+    : Array.from(root.getElementsByTagName("*"));
+
+  stack.forEach((node) => {
+    if (normalizedNames.includes(normalizeName(node.tagName))) {
+      elements.push(node);
+    }
+  });
+
+  return elements;
+}
+
+function findTextByTagNames(element, tagNames) {
+  const match = findFirstElementByTagNames(element, tagNames);
+  return match ? match.textContent.trim() : "";
+}
+
+function findNumberByTagNames(element, tagNames) {
+  const text = findTextByTagNames(element, tagNames);
+  const value = parseNumber(text);
+  return Number.isFinite(value) ? value : NaN;
+}
+
+function findFirstElementByTagNames(element, tagNames) {
+  const normalized = tagNames.map((name) => name.toLowerCase());
+  for (const child of Array.from(element.children)) {
+    if (normalized.includes(normalizeName(child.tagName))) {
+      return child;
+    }
+  }
+  const descendants = element.getElementsByTagName("*");
+  for (const descendant of Array.from(descendants)) {
+    if (normalized.includes(normalizeName(descendant.tagName))) {
+      return descendant;
+    }
+  }
+  return null;
+}
+
+function getAttributeByNames(element, names, asNumber = false) {
+  const normalized = names.map((name) => name.toLowerCase());
+  for (const attribute of Array.from(element.attributes || [])) {
+    if (normalized.includes(normalizeName(attribute.name))) {
+      const value = asNumber ? parseNumber(attribute.value) : attribute.value;
+      if (asNumber) {
+        if (Number.isFinite(value)) {
+          return value;
+        }
+      } else if (value) {
+        return value;
+      }
+    }
+  }
+  return asNumber ? NaN : "";
+}
+
+function parseNumber(value) {
+  if (typeof value !== "string") {
+    return NaN;
+  }
+  const normalized = value.replace(/\s+/g, "").replace(/,/, ".");
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : NaN;
+}
+
+function normalizeName(name) {
+  return (name || "").toString().toLowerCase().split(":").pop();
+}
+
+function formatNumber(value) {
+  const formatter = new Intl.NumberFormat("cs-CZ");
+  return formatter.format(Number(value) || 0);
+}
+
+function decline(value, singular, paucal, plural) {
+  const mod10 = value % 10;
+  const mod100 = value % 100;
+  if (value === 1) {
+    return singular;
+  }
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+    return paucal;
+  }
+  return plural;
+}

--- a/styles.css
+++ b/styles.css
@@ -148,3 +148,80 @@ body {
     padding: 0.75rem 1rem;
   }
 }
+
+.results__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.85rem;
+  background-color: var(--surface-color);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.results__label {
+  font-weight: 600;
+}
+
+.results__select {
+  min-width: min(100%, 280px);
+  padding: 0.55rem 0.9rem;
+  border-radius: 0.65rem;
+  border: 1px solid var(--border-color);
+  background-color: rgba(255, 255, 255, 0.9);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.results__select:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.25);
+}
+
+.region-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0 0.25rem;
+}
+
+.region-header__title {
+  margin: 0;
+  font-size: clamp(1.6rem, 2vw + 0.5rem, 2.1rem);
+}
+
+.region-header__meta {
+  margin: 0;
+  color: var(--muted-color);
+  font-size: 0.95rem;
+}
+
+.region-parties {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.region__notice {
+  margin: 0;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px dashed var(--border-color);
+  color: var(--muted-color);
+  background-color: rgba(255, 255, 255, 0.6);
+  font-style: italic;
+}
+
+@media (max-width: 600px) {
+  .results__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .results__label {
+    font-size: 0.95rem;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,150 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.5;
+  --page-max-width: 960px;
+  --accent-color: #1a73e8;
+  --muted-color: #6b7280;
+  --border-color: rgba(107, 114, 128, 0.3);
+  --positive-color: #127c36;
+  --surface-color: rgba(255, 255, 255, 0.75);
+  background-color: #f3f4f6;
+  color: #111827;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #111827;
+    color: #f9fafb;
+    --border-color: rgba(229, 231, 235, 0.15);
+    --surface-color: rgba(17, 24, 39, 0.6);
+  }
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(26, 115, 232, 0.12), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(18, 124, 54, 0.1), transparent 55%),
+    var(--surface-color);
+}
+
+.page {
+  margin: 0 auto;
+  max-width: var(--page-max-width);
+  padding: 2rem clamp(1rem, 2vw + 0.5rem, 2.5rem) 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.page__header h1 {
+  margin-bottom: 0.5rem;
+  font-weight: 700;
+  font-size: clamp(2rem, 2.5vw + 1rem, 2.75rem);
+}
+
+.page__intro {
+  margin: 0;
+  color: var(--muted-color);
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+  background-color: var(--surface-color);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  font-weight: 500;
+}
+
+.status--error {
+  border-color: #dc2626;
+  color: #991b1b;
+  background: rgba(254, 226, 226, 0.65);
+}
+
+.status--success {
+  border-color: var(--positive-color);
+  color: var(--positive-color);
+  background: rgba(18, 124, 54, 0.08);
+}
+
+.status__icon {
+  font-size: 1.35rem;
+}
+
+.results {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.party {
+  border-radius: 1rem;
+  background-color: var(--surface-color);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.party__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 1.5rem 1.75rem 1.25rem;
+  background: linear-gradient(135deg, rgba(26, 115, 232, 0.15), rgba(18, 124, 54, 0.08));
+}
+
+.party__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 1.8vw + 0.6rem, 2rem);
+}
+
+.party__meta {
+  margin: 0;
+  color: var(--muted-color);
+  font-size: 0.95rem;
+}
+
+.candidate-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.candidate-table thead {
+  background: rgba(26, 115, 232, 0.1);
+  text-align: left;
+}
+
+.candidate-table th,
+.candidate-table td {
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.candidate-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.candidate-table tbody tr.is-qualified {
+  background: rgba(18, 124, 54, 0.08);
+  font-weight: 600;
+}
+
+.candidate-table .candidate-table__note {
+  color: var(--muted-color);
+  font-style: italic;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .candidate-table th,
+  .candidate-table td {
+    padding: 0.75rem 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index page that loads `ps.xml` from the server and shows preferential vote results
- implement flexible XML parsing logic in JavaScript to compute the qualifying threshold and flag candidates who meet it
- style the layout with a responsive design and status messaging for load/error states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db920895b48332869e019b7e76f17b